### PR TITLE
feat: Implement priest list display in ConfessorDashboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.confessionapp">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:name=".ConfessionApplication"
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.ConfessionApp">
+
+        <activity
+            android:name=".ui.ConfessorDashboardActivity"
+            android:exported="true"
+            android:label="Confessor Dashboard">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        {/* TODO: Add other activities, services, receivers etc. here */}
+        {/* TODO: Ensure @string/app_name and @style/Theme.ConfessionApp and launcher icons exist or define them */}
+
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/confessionapp/ConfessionApplication.kt
+++ b/app/src/main/java/com/example/confessionapp/ConfessionApplication.kt
@@ -1,0 +1,41 @@
+package com.example.confessionapp
+
+import android.app.Application
+import com.example.confessionapp.repository.UserRepository
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class ConfessionApplication : Application() {
+
+    // Lazy initialization for services
+    val firestoreInstance: FirebaseFirestore by lazy {
+        Firebase.firestore
+        // Optional: Configure Firestore settings (e.g., persistence)
+        // val settings = FirebaseFirestoreSettings.Builder()
+        //     .setPersistenceEnabled(true)
+        //     .build()
+        // Firebase.firestore.firestoreSettings = settings
+        // Firebase.firestore
+    }
+
+    val userRepository: UserRepository by lazy {
+        UserRepository(firestoreInstance)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        // Initialize FirebaseApp here if not done automatically by FirebaseInitProvider.
+        // FirebaseApp.initializeApp(this)
+
+        // Other app-wide initializations can go here.
+        // For example, Timber for logging:
+        // if (BuildConfig.DEBUG) {
+        //     Timber.plant(Timber.DebugTree())
+        // }
+        Log.d("ConfessionApplication", "Application Created and UserRepository initialized.")
+    }
+}
+
+// Add a Log import for the onCreate message
+import android.util.Log

--- a/app/src/main/java/com/example/confessionapp/data/models/PriestUser.kt
+++ b/app/src/main/java/com/example/confessionapp/data/models/PriestUser.kt
@@ -1,0 +1,14 @@
+package com.example.confessionapp.data.models
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class PriestUser(
+    val uid: String = "",
+    val name: String = "",
+    val email: String = "", // Assuming email might be useful, can be removed if not
+    val photoUrl: String? = null,
+    val languages: List<String> = emptyList(),
+    val isPriestVerified: Boolean = false
+) : Parcelable

--- a/app/src/main/java/com/example/confessionapp/ui/ConfessorDashboardActivity.kt
+++ b/app/src/main/java/com/example/confessionapp/ui/ConfessorDashboardActivity.kt
@@ -1,0 +1,81 @@
+package com.example.confessionapp.ui
+
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.example.confessionapp.R
+import com.example.confessionapp.data.models.PriestUser
+import com.example.confessionapp.repository.UserRepository
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+class ConfessorDashboardActivity : AppCompatActivity() {
+
+    private lateinit var priestsRecyclerView: RecyclerView
+    private lateinit var priestAdapter: PriestAdapter
+    private lateinit var userRepository: UserRepository
+    private lateinit var progressBar: ProgressBar
+    private lateinit var emptyStateTextView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_confessor_dashboard)
+
+        // Initialize UserRepository from Application class
+        userRepository = (application as ConfessionApplication).userRepository
+
+        priestsRecyclerView = findViewById(R.id.priests_recycler_view)
+        progressBar = findViewById(R.id.progress_bar)
+        emptyStateTextView = findViewById(R.id.empty_state_text_view)
+
+        setupRecyclerView()
+        loadVerifiedPriests()
+    }
+
+    private fun setupRecyclerView() {
+        priestAdapter = PriestAdapter { priest ->
+            // Handle priest selection
+            Log.d("ConfessorDashboard", "Selected priest: ${priest.name} (UID: ${priest.uid})")
+            Toast.makeText(this, "Selected: ${priest.name}", Toast.LENGTH_SHORT).show()
+            // TODO: Implement connection logic or navigation to chat/call screen
+        }
+        priestsRecyclerView.apply {
+            layoutManager = LinearLayoutManager(this@ConfessorDashboardActivity)
+            adapter = priestAdapter
+        }
+    }
+
+    private fun loadVerifiedPriests(language: String? = null) {
+        showLoading(true)
+        emptyStateTextView.visibility = View.GONE
+        priestsRecyclerView.visibility = View.GONE
+
+        userRepository.getVerifiedPriests(language) { result ->
+            showLoading(false)
+            result.onSuccess { priests ->
+                if (priests.isNotEmpty()) {
+                    priestAdapter.submitList(priests)
+                    priestsRecyclerView.visibility = View.VISIBLE
+                } else {
+                    emptyStateTextView.text = if (language == null) "No priests available." else "No priests available for the selected language."
+                    emptyStateTextView.visibility = View.VISIBLE
+                }
+            }.onFailure { exception ->
+                Log.e("ConfessorDashboard", "Error loading priests", exception)
+                Toast.makeText(this, "Failed to load priests: ${exception.message}", Toast.LENGTH_LONG).show()
+                emptyStateTextView.text = "Error loading priests."
+                emptyStateTextView.visibility = View.VISIBLE
+            }
+        }
+    }
+
+    private fun showLoading(isLoading: Boolean) {
+        progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+    }
+}

--- a/app/src/main/java/com/example/confessionapp/ui/PriestAdapter.kt
+++ b/app/src/main/java/com/example/confessionapp/ui/PriestAdapter.kt
@@ -1,0 +1,63 @@
+package com.example.confessionapp.ui
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.example.confessionapp.R
+import com.example.confessionapp.data.models.PriestUser
+// TODO: Import a library like Glide or Picasso for image loading if priest_image_view is used with URLs
+
+class PriestAdapter(
+    private val onItemClicked: (PriestUser) -> Unit
+) : ListAdapter<PriestUser, PriestAdapter.PriestViewHolder>(PriestDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PriestViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_priest_card, parent, false)
+        return PriestViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: PriestViewHolder, position: Int) {
+        val priest = getItem(position)
+        holder.bind(priest)
+        holder.itemView.setOnClickListener {
+            onItemClicked(priest)
+        }
+    }
+
+    class PriestViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val nameTextView: TextView = itemView.findViewById(R.id.priest_name_text_view)
+        private val languagesTextView: TextView = itemView.findViewById(R.id.priest_languages_text_view)
+        private val imageView: ImageView = itemView.findViewById(R.id.priest_image_view) // Placeholder for image loading
+
+        fun bind(priest: PriestUser) {
+            nameTextView.text = priest.name
+            languagesTextView.text = priest.languages.joinToString(", ")
+
+            // TODO: Load image using Glide/Picasso if photoUrl is available
+            // For now, you can set a placeholder or leave it as is if using tools:srcCompat
+            // Example:
+            // if (!priest.photoUrl.isNullOrEmpty()) {
+            // Glide.with(imageView.context).load(priest.photoUrl).into(imageView)
+            // } else {
+            // imageView.setImageResource(R.drawable.default_avatar) // a default placeholder
+            // }
+            // Using placeholder from XML for now via tools:srcCompat
+        }
+    }
+
+    private class PriestDiffCallback : DiffUtil.ItemCallback<PriestUser>() {
+        override fun areItemsTheSame(oldItem: PriestUser, newItem: PriestUser): Boolean {
+            return oldItem.uid == newItem.uid
+        }
+
+        override fun areContentsTheSame(oldItem: PriestUser, newItem: PriestUser): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_confessor_dashboard.xml
+++ b/app/src/main/res/layout/activity_confessor_dashboard.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.ConfessorDashboardActivity">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/priests_recycler_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:listitem="@layout/item_priest_card" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:visibility="visible"/>
+
+    <TextView
+        android:id="@+id/empty_state_text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No priests available at the moment."
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:visibility="gone"/>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_priest_card.xml
+++ b/app/src/main/res/layout/item_priest_card.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardElevation="4dp"
+    app:cardCornerRadius="8dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <ImageView
+            android:id="@+id/priest_image_view"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:scaleType="centerCrop"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:srcCompat="@tools:sample/avatars" />
+
+        <TextView
+            android:id="@+id/priest_name_text_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            app:layout_constraintStart_toEndOf="@id/priest_image_view"
+            app:layout_constraintTop_toTopOf="@id/priest_image_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="Father John Doe" />
+
+        <TextView
+            android:id="@+id/priest_languages_text_view"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="4dp"
+            android:textAppearance="?attr/textAppearanceBody2"
+            app:layout_constraintStart_toEndOf="@id/priest_image_view"
+            app:layout_constraintTop_toBottomOf="@id/priest_name_text_view"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/priest_image_view"
+            tools:text="English, Spanish" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/test/java/com/example/confessionapp/repository/UserRepositoryTest.kt
+++ b/app/src/test/java/com/example/confessionapp/repository/UserRepositoryTest.kt
@@ -1,0 +1,240 @@
+package com.example.confessionapp.repository
+
+import com.example.confessionapp.data.models.PriestUser
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.Query
+import com.google.firebase.firestore.QuerySnapshot
+import io.mockk.*
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.Assert.*
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.util.concurrent.Executor
+
+// Use RobolectricTestRunner for any Android specific classes if needed, though trying to avoid them for pure unit tests.
+// If Log.d, etc. from Android are used in UserRepository, Robolectric might be needed or specific mocking for Log.
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest=Config.NONE, sdk = [28]) // Basic config for Robolectric if Android SDK stubs are needed
+class UserRepositoryTest {
+
+    private lateinit var mockFirestore: FirebaseFirestore
+    private lateinit var mockCollectionRef: CollectionReference
+    private lateinit var mockQuery: Query
+    private lateinit var userRepository: UserRepository
+
+    // Task implementation for mocking Firebase calls
+    private class MockTask<TResult>(private val result: TResult?, private val exception: Exception?) : Task<TResult>() {
+        private var successListener: OnSuccessListener<in TResult>? = null
+        private var failureListener: OnFailureListener? = null
+        private var complete = false
+
+        override fun isComplete(): Boolean = complete
+        override fun isSuccessful(): Boolean = exception == null && complete
+        override fun isCanceled(): Boolean = false
+        override fun getResult(): TResult = if (exception == null) result!! else throw RuntimeException("Task failed", exception)
+        override fun <X : Throwable?> getResult(p0: Class<X>): TResult = result!! // Simplified
+        override fun getException(): Exception? = exception
+
+        override fun addOnSuccessListener(p0: Executor, p1: OnSuccessListener<in TResult>): Task<TResult> {
+            this.successListener = p1
+            // Simulate async completion for testing
+            if (exception == null) {
+                mockkStatic(android.os.Looper::class)
+                every { android.os.Looper.getMainLooper() } returns mockk(relaxed = true)
+
+                // Directly invoke listener for simplicity in test
+                // In a real scenario, you might use a test executor
+                 p0.execute { successListener?.onSuccess(result) }
+                 complete = true
+            }
+            return this
+        }
+         override fun addOnSuccessListener(p1: OnSuccessListener<in TResult>): Task<TResult> {
+            this.successListener = p1
+            // Simulate async completion for testing
+            if (exception == null) {
+                 successListener?.onSuccess(result)
+                 complete = true
+            }
+            return this
+        }
+
+        override fun addOnFailureListener(p0: Executor, p1: OnFailureListener): Task<TResult> {
+            this.failureListener = p1
+            if (exception != null) {
+                 p0.execute { failureListener?.onFailure(exception) }
+                 complete = true
+            }
+            return this
+        }
+         override fun addOnFailureListener(p1: OnFailureListener): Task<TResult> {
+            this.failureListener = p1
+            if (exception != null) {
+                 failureListener?.onFailure(exception)
+                 complete = true
+            }
+            return this
+        }
+    }
+
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true) // Initialize MockK
+        mockFirestore = mockk()
+        mockCollectionRef = mockk()
+        mockQuery = mockk()
+
+        every { mockFirestore.collection("users") } returns mockCollectionRef
+        every { mockCollectionRef.whereEqualTo(any<String>(), any()) } returns mockQuery
+        every { mockQuery.whereArrayContains(any<String>(), any()) } returns mockQuery // For language filter
+
+        userRepository = UserRepository(mockFirestore)
+
+        // Mock Log calls to prevent Android SDK dependency issues in pure JVM tests if not using Robolectric
+        mockkStatic(Log::class)
+        every { Log.e(any(), any(), any()) } returns 0
+        every { Log.d(any(), any()) } returns 0
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll() // Clear mocks after each test
+    }
+
+    @Test
+    fun `getVerifiedPriests returns list of priests on success`() {
+        val mockDocument1 = mockk<DocumentSnapshot>()
+        every { mockDocument1.id } returns "priest1"
+        every { mockDocument1.getString("name") } returns "Father John"
+        every { mockDocument1.getString("email") } returns "john@example.com"
+        every { mockDocument1.getString("photoUrl") } returns null
+        every { mockDocument1.get("languages") } returns listOf("English", "Spanish")
+        every { mockDocument1.getBoolean("isPriestVerified") } returns true
+
+        val mockDocument2 = mockk<DocumentSnapshot>()
+        every { mockDocument2.id } returns "priest2"
+        every { mockDocument2.getString("name") } returns "Father Mike"
+        every { mockDocument2.getString("email") } returns "mike@example.com"
+        every { mockDocument2.getString("photoUrl") } returns "url"
+        every { mockDocument2.get("languages") } returns listOf("English")
+        every { mockDocument2.getBoolean("isPriestVerified") } returns true
+
+        val mockDocument3NotVerified = mockk<DocumentSnapshot>() // Not verified
+        every { mockDocument3NotVerified.id } returns "user3"
+        every { mockDocument3NotVerified.getString("name") } returns "User NotAPriest"
+        every { mockDocument3NotVerified.getBoolean("isPriestVerified") } returns false
+
+
+        val mockQuerySnapshot = mockk<QuerySnapshot>()
+        every { mockQuerySnapshot.documents } returns listOf(mockDocument1, mockDocument2, mockDocument3NotVerified)
+
+        val mockTask = MockTask<QuerySnapshot>(mockQuerySnapshot, null)
+        every { mockQuery.get() } returns mockTask
+
+        var resultList: List<PriestUser>? = null
+        userRepository.getVerifiedPriests { result ->
+            result.onSuccess { priests ->
+                resultList = priests
+            }
+        }
+
+        assertNotNull("Result list should not be null", resultList)
+        assertEquals("Should return 2 verified priests", 2, resultList?.size)
+        assertEquals("Priest1 name mismatch", "Father John", resultList?.get(0)?.name)
+        assertEquals("Priest2 UID mismatch", "priest2", resultList?.get(1)?.uid)
+        assertTrue("Priest2 should have English language", resultList?.get(1)?.languages?.contains("English") == true)
+    }
+
+    @Test
+    fun `getVerifiedPriests with language filter returns filtered list`() {
+        val mockDocument1 = mockk<DocumentSnapshot>()
+        every { mockDocument1.id } returns "priest1"
+        every { mockDocument1.getString("name") } returns "Father Spanish"
+        every { mockDocument1.get("languages") } returns listOf("Spanish")
+        every { mockDocument1.getBoolean("isPriestVerified") } returns true
+
+        val mockDocument2 = mockk<DocumentSnapshot>() // English only
+        every { mockDocument2.id } returns "priest2"
+        every { mockDocument2.getString("name") } returns "Father English"
+        every { mockDocument2.get("languages") } returns listOf("English")
+        every { mockDocument2.getBoolean("isPriestVerified") } returns true
+
+        val mockQuerySnapshot = mockk<QuerySnapshot>()
+        every { mockQuerySnapshot.documents } returns listOf(mockDocument1, mockDocument2)
+
+        val mockTask = MockTask<QuerySnapshot>(mockQuerySnapshot, null)
+        every { mockQuery.get() } returns mockTask
+
+
+        var resultList: List<PriestUser>? = null
+        userRepository.getVerifiedPriests("Spanish") { result -> // Filter by Spanish
+            result.onSuccess { priests -> resultList = priests }
+        }
+
+        assertNotNull(resultList)
+        assertEquals("Should return 1 priest speaking Spanish", 1, resultList?.size)
+        assertEquals("Priest name mismatch", "Father Spanish", resultList?.get(0)?.name)
+
+        verify { mockCollectionRef.whereEqualTo("isPriestVerified", true) } // Base query
+        verify { mockQuery.whereArrayContains("languages", "Spanish") } // Language filter
+    }
+
+
+    @Test
+    fun `getVerifiedPriests returns failure on Firestore error`() {
+        val exception = Exception("Firestore error")
+        val mockTask = MockTask<QuerySnapshot>(null, exception)
+        every { mockQuery.get() } returns mockTask
+
+        var resultError: Throwable? = null
+        userRepository.getVerifiedPriests { result ->
+            result.onFailure { error ->
+                resultError = error
+            }
+        }
+        assertNotNull("Error should not be null", resultError)
+        assertEquals("Error message mismatch", "Firestore error", resultError?.message)
+    }
+
+    @Test
+    fun `getVerifiedPriests handles document parsing error gracefully`() {
+        val mockDocumentCorrect = mockk<DocumentSnapshot>()
+        every { mockDocumentCorrect.id } returns "priestCorrect"
+        every { mockDocumentCorrect.getString("name") } returns "Father Correct"
+        every { mockDocumentCorrect.get("languages") } returns listOf("English")
+        every { mockDocumentCorrect.getBoolean("isPriestVerified") } returns true
+
+        val mockDocumentBroken = mockk<DocumentSnapshot>() // This one will cause a parsing error
+        every { mockDocumentBroken.id } returns "priestBroken"
+        every { mockDocumentBroken.getString("name") } returns "Father Broken"
+        // Intentionally make languages a wrong type to simulate parsing error
+        every { mockDocumentBroken.get("languages") } returns "not_a_list"
+        every { mockDocumentBroken.getBoolean("isPriestVerified") } returns true
+
+
+        val mockQuerySnapshot = mockk<QuerySnapshot>()
+        every { mockQuerySnapshot.documents } returns listOf(mockDocumentCorrect, mockDocumentBroken)
+
+        val mockTask = MockTask<QuerySnapshot>(mockQuerySnapshot, null)
+        every { mockQuery.get() } returns mockTask
+
+        var resultList: List<PriestUser>? = null
+        userRepository.getVerifiedPriests { result ->
+            result.onSuccess { priests -> resultList = priests }
+        }
+
+        assertNotNull(resultList)
+        assertEquals("Should return only 1 correctly parsed priest", 1, resultList?.size)
+        assertEquals("priestCorrect", resultList?.get(0)?.uid)
+        verify { Log.e("UserRepository", "Error parsing priest document priestBroken", any()) }
+    }
+}


### PR DESCRIPTION
This commit introduces the functionality for confessors to see a list of available priests.

Key changes:
- Created `PriestUser` data model.
- Extended `UserRepository` with `getVerifiedPriests` to fetch priests from Firestore, with optional language filtering.
- Added `item_priest_card.xml` layout for individual priest items.
- Implemented `PriestAdapter` to bind priest data to the RecyclerView.
- Created `ConfessorDashboardActivity` and its layout (`activity_confessor_dashboard.xml`) to display the priest list using a RecyclerView.
- Included basic loading and empty states in the dashboard.
- Established `ConfessionApplication` class for centralized repository initialization.
- Added `ConfessorDashboardActivity` to a new `AndroidManifest.xml` and set it as the launcher.
- Added unit tests for `UserRepository.getVerifiedPriests` method.